### PR TITLE
Changed the ep version validation

### DIFF
--- a/BuildME/pre.py
+++ b/BuildME/pre.py
@@ -19,11 +19,16 @@ def validate_ep_version(folders=settings.archetypes,crash=False):
     :return:
     """
     # Check if energyplus version matches the one of the binary
-    # Fragile function assuming the version is separated by '-'
-    bin_ver = settings.ep_path.split('-')[-3:]
-    if '.'.join(bin_ver) != settings.ep_version:
+    try:
+        with open(settings.ep_idd, mode='r') as f:
+            bin_ver = f.readline().strip().split()[1]  # Extract the version from the IDD file's first line, e.g. '!IDD_Version 9.2.0'
+    except FileNotFoundError:
+        bin_ver = None
+        print("'Energy+.idd' can't be found.")
+
+    if bin_ver != settings.ep_version:
         err = "WARNING: energyplus version in settings (%s) does not match implied version (%s) from path (%s)" \
-              % (settings.ep_version, '.'.join(bin_ver), settings.ep_path)
+              % (settings.ep_version, bin_ver, settings.ep_idd)
         if crash:
             raise AssertionError(err)
         else:

--- a/BuildME/settings.py
+++ b/BuildME/settings.py
@@ -7,10 +7,14 @@ Copyright: Niko Heeren, 2019
 import os
 import platform
 
+# Setting the required paths
 ep_version = '9.2.0'
 basepath = os.path.abspath('.')
 ep_path = os.path.abspath("./bin/EnergyPlus-9-2-0/")
 ep_idd = os.path.abspath(os.path.join(ep_path, "Energy+.idd"))
+archetypes = os.path.abspath("./data/archetype/")
+tmp_path = os.path.abspath("./tmp/")
+climate_files_path = os.path.abspath("./data/climate/meteonorm71/")
 
 # Checking OS and modify files to copy
 platform = platform.system()
@@ -31,9 +35,7 @@ elif platform == 'Darwin':
 else:
     raise NotImplementedError('OS is not supported!')
 
-archetypes = os.path.abspath("./data/archetype/")
-tmp_path = os.path.abspath("./tmp/")
-climate_files_path = os.path.abspath("./data/climate/meteonorm71/")
+
 shielding = 'medium'  # wind shielding, needed for MMV simulations; set to low, medium or high
 
 # The combinations
@@ -470,8 +472,8 @@ odym_regions = {'USA': 'R32USA',
                 'PL': 'Poland',
                 'ES': 'Spain',
                 'UK': 'UK',
-                'Oth-R32EU15': 'Oth-R32EU15',
-                'Oth-R32EU12-H': 'Oth-R32EU12-H',
+                'Oth-R32EU15': 'Oth_R32EU15',
+                'Oth-R32EU12-H': 'Oth_R32EU12-H',
                 'Oth-OECD': 'R5.2OECD_Other',
                 'Oth-REF': 'R5.2REF_Other',
                 'Oth-Asia': 'R5.2ASIA_Other',


### PR DESCRIPTION
Based on #54 , I modified the pre.py file so that it reads the version directly from the 'Energy+.idd' file.

The new code tries to open the file, then:
- it splits the first line ('!IDD_Version 9.2.0')
- accesses the second part of the array (['!IDD_Version',  '9.2.0'])
- creates the variable bin_ver = 9.2.0

I didn't try launching main.py using the new pre.py file, but the pre.py file itself (validate_ep_version) ran successfully after the fix.